### PR TITLE
Small label tweaks for ForceGraphNode and ForceGraphLink

### DIFF
--- a/gui/src/ts/components/benchmark/BenchmarkAnswerChoiceAnalysisGraph.tsx
+++ b/gui/src/ts/components/benchmark/BenchmarkAnswerChoiceAnalysisGraph.tsx
@@ -241,6 +241,7 @@ export const BenchmarkAnswerChoiceAnalysisGraph: React.FunctionComponent<{
                 fill={colorScale(score)}
                 opacity={score}
                 cursor="pointer"
+                showLabel
               >
                 <title>{node.label}</title>
               </ForceGraphNode>
@@ -254,7 +255,8 @@ export const BenchmarkAnswerChoiceAnalysisGraph: React.FunctionComponent<{
               link={link}
               stroke={colorScale(link.score)}
               targetRadius={nodeRadius(nodes[link.targetId])}
-              opacity={link.score * 0.6}
+              opacity={link.score}
+              showLabel
             />
           ))}
       </ForceGraph>
@@ -366,34 +368,39 @@ const QuestionAnswerPathGraphs: React.FunctionComponent<{
                 stroke = "purple";
               }
 
+              const focused = node.paths.some(
+                (path) => path.id === highestScorePathId
+              );
+
               return (
                 <ForceGraphNode
                   key={node.id}
                   node={node}
                   r={nodeRadius(node)}
                   fill={colorScale(score)}
-                  opacity={
-                    node.paths.some((path) => path.id === highestScorePathId)
-                      ? 1
-                      : 0.2
-                  }
+                  fillOpacity={score}
                   cursor="pointer"
                   stroke={stroke}
                   strokeWidth={4}
+                  showLabel={focused}
                 >
                   <title>{node.label}</title>
                 </ForceGraphNode>
               );
             })}
-            {links.map((link) => (
-              <ForceGraphArrowLink
-                key={link.id}
-                link={link}
-                stroke={colorScale(link.score)}
-                targetRadius={nodeRadius(nodesIndexed[link.targetId])}
-                opacity={highestScorePathId === link.pathId ? 1 : 0.2}
-              />
-            ))}
+            {links.map((link) => {
+              const focused = highestScorePathId === link.pathId;
+              return (
+                <ForceGraphArrowLink
+                  key={link.id}
+                  link={link}
+                  stroke={colorScale(link.score)}
+                  targetRadius={nodeRadius(nodesIndexed[link.targetId])}
+                  showLabel={focused}
+                  opacity={focused ? 1 : link.score}
+                />
+              );
+            })}
           </ForceGraph>
         </Grid>
         <Grid item md={8}>

--- a/gui/src/ts/components/data/forceGraph/ForceGraphLink.tsx
+++ b/gui/src/ts/components/data/forceGraph/ForceGraphLink.tsx
@@ -9,6 +9,8 @@ const defaultLinkOptions: React.SVGProps<SVGLineElement> = {
 
 export type ForceGraphLinkProps<LinkDatum> = React.SVGProps<SVGLineElement> & {
   link: LinkDatum;
+  showLabel?: boolean;
+  labelOpacity?: number;
 };
 
 export const ForceGraphLink = <
@@ -19,18 +21,29 @@ export const ForceGraphLink = <
   opacity,
   onClick,
   fontSize: userDefinedFontSize,
+  labelOpacity: userDefinedLabelOpacity,
+  showLabel,
   ...props
 }: ForceGraphLinkProps<LinkDatum>) => {
   const fontSize = userDefinedFontSize ?? 10;
+  const labelOpacity = userDefinedLabelOpacity ?? opacity ?? 1;
 
   return (
     <g id={link.id} className="link" opacity={opacity} onClick={onClick}>
       <line {...defaultLinkOptions} {...props} />
 
-      <text fontSize={fontSize} stroke="white" strokeWidth={2}>
-        {link.label}
-      </text>
-      <text fontSize={fontSize}>{link.label}</text>
+      {showLabel && (
+        <>
+          {labelOpacity > 0.8 && (
+            <text fontSize={fontSize} stroke="white" strokeWidth={2}>
+              {link.label}
+            </text>
+          )}
+          <text fontSize={fontSize} fillOpacity={labelOpacity}>
+            {link.label}
+          </text>
+        </>
+      )}
     </g>
   );
 };

--- a/gui/src/ts/components/data/forceGraph/ForceGraphNode.tsx
+++ b/gui/src/ts/components/data/forceGraph/ForceGraphNode.tsx
@@ -12,6 +12,8 @@ export type ForceGraphNodeProps<NodeDatum> = React.SVGProps<
   SVGCircleElement
 > & {
   node: NodeDatum;
+  showLabel?: boolean;
+  labelOpacity?: number;
 };
 
 export const ForceGraphNode = <NodeDatum extends ForceGraphNodeDatum>({
@@ -21,10 +23,13 @@ export const ForceGraphNode = <NodeDatum extends ForceGraphNodeDatum>({
   onClick,
   fontSize: userDefinedFontSize,
   r,
+  showLabel,
+  labelOpacity: userDefinedLabelOpacity,
   ...props
 }: ForceGraphNodeProps<NodeDatum>) => {
   const radius = r ?? 10;
   const fontSize = userDefinedFontSize ?? radius;
+  const labelOpacity = userDefinedLabelOpacity ?? opacity ?? 1;
 
   return (
     <g
@@ -36,10 +41,19 @@ export const ForceGraphNode = <NodeDatum extends ForceGraphNodeDatum>({
     >
       <circle {...defaultNodeOptions} {...props} r={radius} />
 
-      <text fontSize={fontSize} strokeWidth={2} stroke="white">
-        {node.label}
-      </text>
-      <text fontSize={fontSize}>{node.label}</text>
+      {showLabel && (
+        <>
+          {labelOpacity > 0.8 && (
+            <text fontSize={fontSize} strokeWidth={2} stroke="white">
+              {node.label}
+            </text>
+          )}
+
+          <text fontSize={fontSize} fillOpacity={labelOpacity}>
+            {node.label}
+          </text>
+        </>
+      )}
     </g>
   );
 };


### PR DESCRIPTION
Add `showLabel` to control label render
Add `labelOpacity` which allows separate label and node/link opacity
Remove white outline for text if opacity is less than 0.8
- This helps non-focused labels to be much less intrusive and fade into the background more


Setting up for mouseover label control as described in #125 
Targeting `ForceGraph` general purpose functionality to avoid conflict with ongoing model change